### PR TITLE
add support for npm 3+

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "type": "git",
     "url": "https://github.com/kirjs/react-highcharts"
   },
-  "peerDependencies": {
+  "dependencies": {
     "react": "*"
   },
   "bugs": "https://github.com/kirjs/react-highcharts/issues",


### PR DESCRIPTION
npm WARN peerDependencies The peer dependency react@* included from react-highcharts will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.


npm ERR! peerinvalid The package react does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer react-highcharts@2.0.0 wants react@*
