### PR TITLE
get rid of modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ Or use bundled version:  `require('react-highcharts/dist/bundle/highstock');`
 * see [the demo](http://kirjs.github.io/react-highcharts/highstock.html)
 
 ## Using highcharts modules/add-ons like exporting, data, etc.
-Just require `require('react-highcharts/modules/MODULE_NAME');` after requiring `react-highcharts`
+Everything related to modules was moved out of `react-highcharts`. 
+Now every highcharts module is published as a separate npm package. 
+You can find the full list list [here](https://github.com/kirjs/publish-highcharts-modules/blob/master/modules.md)
+* see [the demo](http://kirjs.github.io/react-highcharts/more.html)
 
 ## For Contributors
 ### Update Highcharts Version 

--- a/demo/src/more.jsx
+++ b/demo/src/more.jsx
@@ -1,6 +1,6 @@
 var React = require('react');
 var Highcharts = require('react-highcharts/bundle/highcharts');
-require('react-highcharts/modules/more');
+require('highcharts-more');
 var Highlight = require('react-highlight');
 var ReactDOM = require('react-dom');
 


### PR DESCRIPTION
All modules were moved out to separate npm packages, so we don't have to maintain them as a part of `react-highcharts`.