### PR TITLE
return false when props haven't changed

### DIFF
--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -33,8 +33,9 @@ module.exports = function (Highcharts, chartType) {
     shouldComponentUpdate(nextProps) {
       if (!this.props.isPureConfig || !(this.props.config === nextProps.config)) {
         this.renderChart(nextProps.config);
+        return true;
       }
-      return true;
+      return false;
     },
 
     getChart: function () {


### PR DESCRIPTION
When props have not changed shouldComponentUpdate should return false. 

This will prevent the charts from loading multiple times if a container calls setState, etc.