### PR TITLE
addListener to mediaQuery print to redraw the chart

### DIFF
--- a/recipes.md
+++ b/recipes.md
@@ -3,23 +3,23 @@
 ## Using with highcharts-release package
 Thanks [@mblakele](https://github.com/mblakele) for writing this out.
 
-First install both libraries: 
+First install both libraries:
 ```bash
 npm install highcharts-release --save
-npm install react-highcharts --save	
+npm install react-highcharts --save
 ```
 
-Now use them together: 
+Now use them together:
 
 ```jsx
-var React = require('react');	
+var React = require('react');
 
 // With webpack you may wish to alias this as 'highcharts-release'
-var Highcharts = require('highcharts-release/highcharts.src.js'); 
+var Highcharts = require('highcharts-release/highcharts.src.js');
 
 // Expects that Highcharts was loaded in the code.
-var ReactHighcharts = require('react-highcharts'); 
- 
+var ReactHighcharts = require('react-highcharts');
+
 var config = {
   /* HighchartsConfig */		
 };
@@ -27,8 +27,8 @@ var config = {
 React.render(<Highcharts config = {config}></Highcharts>, document.body);		
 ```
 
-## Rendering react-highcharts on node. 
-There is no simple way to render Highcharts in node, so contributions are welcome to this section. 
+## Rendering react-highcharts on node.
+There is no simple way to render Highcharts in node, so contributions are welcome to this section.
 
 At this point the simplest solution would be to have a node-specific `Highcharts`
  [version](https://github.com/kirjs/react-highcharts/blob/master/src/fakeHighcharts.js)
@@ -40,5 +40,22 @@ if(!Highcharts){
   global.highcharts = require('react-highcharts/src/fakeHighcharts.js');  
 }
 ```
-Browser will have real Highcharts instead, and would rerender the chart on top of it. 
+Browser will have real Highcharts instead, and would rerender the chart on top of it.
 
+## Resize react-highcharts when printing website.
+Since highcharts doesn't reflow upon print media query. Wrap your chart in `RedrawOnPrint` component.
+
+```jsx
+  import ReactHighcharts from 'react-highcharts/bundle/highcharts';
+  import RedrawOnPrint from 'react-highcharts/RedrawOnPrint';
+
+  class MyComponent extends React.Component {
+    render() {
+      return (
+        <RedrawOnPrint>
+          <ReactHighcharts config = {config} />
+        </RedrawOnPrint>
+      );
+    }
+  }
+```

--- a/src/RedrawOnPrint.jsx
+++ b/src/RedrawOnPrint.jsx
@@ -1,0 +1,50 @@
+var React = require('react');
+
+var RedrawOnPrint = React.createClass({
+  componentDidMount: function() {
+    // This is a listiner bind to the print media query
+    // it call reflow since highcharts doesn't reflow upon print
+    // http://stackoverflow.com/questions/32821003/redraw-resize-highcharts-when-printing-website
+    if (window.matchMedia) {
+      var mediaQueryList = window.matchMedia('print');
+      mediaQueryList.addListener(this._reflowChildren);
+    }
+  },
+  componentWillUnmount: function() {
+    if (window.matchMedia) {
+      var mediaQueryList = window.matchMedia('print');
+      mediaQueryList.removeListener(this._reflowChildren);
+    }
+  },
+
+  _reflowChildren() {
+    if (this.children) {
+      this.children.map((child) => {
+        if (!child || !child.chart) {
+          throw new Error('RedrawOnPrint child should be a highcharts');
+        }
+        child.chart.reflow();
+      });
+    }
+  },
+
+  render: function() {
+    return (
+      <div>
+        {React.Children.map(this.props.children, (child) => {
+          return React.cloneElement(child, {
+            ref: (c) => {
+              if (!this.children) {
+                this.children = [];
+              }
+              this.children.push(c);
+            }
+          })
+        })}
+      </div>
+    );
+  }
+
+});
+
+module.exports = RedrawOnPrint;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ module.exports = {
     'highcharts': ['./src/Highcharts.jsx'],
     'highstock': ['./src/Highstock.jsx'],
     'highmaps': ['./src/Highmaps.jsx'],
+    'RedrawOnPrint': ['./src/RedrawOnPrint.jsx'],
     'bundle/index': './src/bundle/Highcharts.jsx',
     'bundle/highcharts': './src/bundle/Highcharts.jsx',
     'bundle/highstock': './src/bundle/Highstock.jsx',


### PR DESCRIPTION
The problem is that while the chart adjusts to resize events in the browser, those events are not triggered when creating a print. This PR resize the chart upon print. Im open to discussion