### PR TITLE
Corrected RedrawOnPrint directory

### DIFF
--- a/recipes.md
+++ b/recipes.md
@@ -46,7 +46,7 @@ Since highcharts doesn't reflow upon print media query. Wrap your chart in `Redr
 
 ```jsx
   import ReactHighcharts from 'react-highcharts/bundle/ReactHighcharts';
-  import RedrawOnPrint from 'react-highcharts/RedrawOnPrint';
+  import RedrawOnPrint from 'react-highcharts/dist/RedrawOnPrint';
 
   class MyComponent extends React.Component {
     render() {


### PR DESCRIPTION
Docs pointed at a directory where no `RedrawOnPrint` file existed. Only one I saw was on `dist/`.