### PR TITLE
[RedrawOnPrint] Clearing children array on render

### DIFF
--- a/src/RedrawOnPrint.jsx
+++ b/src/RedrawOnPrint.jsx
@@ -1,7 +1,7 @@
 var React = require('react');
 
 var RedrawOnPrint = React.createClass({
-  componentDidMount: function (){
+  componentDidMount() {
     // This is a listiner bind to the print media query
     // it call reflow since highcharts doesn't reflow upon print
     // http://stackoverflow.com/questions/32821003/redraw-resize-highcharts-when-printing-website
@@ -11,7 +11,7 @@ var RedrawOnPrint = React.createClass({
     }
   },
 
-  componentWillUnmount: function (){
+  componentWillUnmount() {
     if (window.matchMedia) {
       var mediaQueryList = window.matchMedia('print');
       mediaQueryList.removeListener(this._reflowChildren);
@@ -19,29 +19,23 @@ var RedrawOnPrint = React.createClass({
   },
 
   _reflowChildren() {
-    if (this.children) {
-      this.children.map((child) =>{
-        if (!child || !child.chart) {
-          throw new Error('RedrawOnPrint child should be a highcharts');
-        }
-        child.chart.reflow();
-      });
-    }
+    this.children.map((child) =>{
+      if (!child || !child.chart) {
+        throw new Error('RedrawOnPrint child should be a highcharts');
+      }
+      child.chart.reflow();
+    });
   },
 
-  render: function (){
+  render() {
+    this.children = [];
     return (
       <div>
         {React.Children.map(this.props.children, (child) => {
           return React.cloneElement(child, {
-            ref: (c) => {
-              if (!this.children) {
-                this.children = [];
-                }
-              this.children.push(c);
-              }
-            })
-          })}
+            ref: (c) => c && this.children.push(c)
+          })
+        })}
       </div>
     );
   }


### PR DESCRIPTION
I just realized that we pushed the same component over and over again each time the parent re-render.
This PR clear the child array and push the new one. I also did a basic check to prevent pushing `null`.
>Also note that when writing refs with inline function expressions as in the examples here, React sees a different function object each time so on every update, ref will be called with null immediately before it's called with the component instance.
https://facebook.github.io/react/docs/more-about-refs.html