### PR TITLE
Allow developer to explicitly specify that no update should happen.

### DIFF
--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -30,10 +30,10 @@ module.exports = function (chartType, Highcharts){
     },
 
     shouldComponentUpdate(nextProps) {
-      if (!this.props.neverReflow && (!this.props.isPureConfig || !(this.props.config === nextProps.config))) {
-        this.renderChart(nextProps.config);
+      if (this.props.neverReflow || (this.props.isPureConfig  && this.props.config === nextProps.config)) {
+        return true;
       }
-      return true;
+      this.renderChart(nextProps.config);
     },
 
     getChart: function (){

--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -7,11 +7,8 @@ module.exports = function (chartType, Highcharts){
 
     propTypes: {
       config: React.PropTypes.object.isRequired,
-      isPureConfig: React.PropTypes.bool
-    },
-
-    propDefaults: {
-      isPureConfig: null,
+      isPureConfig: React.PropTypes.bool,
+      neverReflow: React.PropTypes.bool
     },
 
     renderChart: function (config){
@@ -33,9 +30,7 @@ module.exports = function (chartType, Highcharts){
     },
 
     shouldComponentUpdate(nextProps) {
-      // if isPureConfig is explicitly false, don't bother comparing configs, otherwise compare if not explicitly true
-      if (this.props.isPureConfig === false
-          || (this.props.isPureConfig !== true && !(this.props.config === nextProps.config))) {
+      if (!this.props.neverReflow && (!this.props.isPureConfig || !(this.props.config === nextProps.config))) {
         this.renderChart(nextProps.config);
       }
       return true;

--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -10,6 +10,10 @@ module.exports = function (chartType, Highcharts){
       isPureConfig: React.PropTypes.bool
     },
 
+    propDefaults: {
+      isPureConfig: null,
+    },
+
     renderChart: function (config){
       if (!config) {
         throw new Error('Config must be specified for the ' + displayName + ' component');
@@ -29,7 +33,9 @@ module.exports = function (chartType, Highcharts){
     },
 
     shouldComponentUpdate(nextProps) {
-      if (!this.props.isPureConfig || !(this.props.config === nextProps.config)) {
+      // if isPureConfig is explicitly false, don't bother comparing configs, otherwise compare if not explicitly true
+      if (this.props.isPureConfig === false
+          || (this.props.isPureConfig !== true && !(this.props.config === nextProps.config))) {
         this.renderChart(nextProps.config);
       }
       return true;

--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -34,6 +34,7 @@ module.exports = function (chartType, Highcharts){
         return true;
       }
       this.renderChart(nextProps.config);
+      return false;
     },
 
     getChart: function (){

--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -25,8 +25,8 @@ module.exports = function (chartType, Highcharts){
       });
 
       global.requestAnimationFrame && requestAnimationFrame(()=>{
-        this.chart.reflow()
-      })
+        this.chart && this.chart.reflow();
+      });
     },
 
     shouldComponentUpdate(nextProps) {


### PR DESCRIPTION
This allows the component consumer to use isPureConfig even if the config object is not the exact same object as previously (useful with immutable stores that copy-on-read).

if isPureConfig is neither true nor false, the code falls back to triple-equal-compare.