### PR TITLE
React 15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "url": "https://github.com/kirjs/react-highcharts"
   },
   "peerDependencies": {
-    "react": "~0.14",
-    "react-dom": "~0.14"
+    "react": "~0.14 || ^15.0.0",
+    "react-dom": "~0.14 || ^15.0.0"
   },
   "bugs": "https://github.com/kirjs/react-highcharts/issues",
   "keywords": [
@@ -46,9 +46,9 @@
     "mocha": "^2.3.0",
     "proxyquire": "^1.7.4",
     "raw-loader": "^0.5.1",
-    "react": "~0.14",
-    "react-addons-test-utils": "^0.14.0",
-    "react-dom": "~0.14",
+    "react": "^15.0.0",
+    "react-addons-test-utils": "^15.0.0",
+    "react-dom": "^15.0.0",
     "react-highlight": "^0.7.0",
     "webpack": "^1.5.3",
     "webpack-dev-server": "^1.10.1"


### PR DESCRIPTION
Currently, installing `react-highcharts` in a project using React `15.x` gives peer dependency warnings. This PR adds ^15.0.0 in the React.js range.

`npm test` passes. I've tested it with my application and it worked fine too.