### PR TITLE
consider nextProps in shouldComponentUpdate instead of this.props

### DIFF
--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -35,7 +35,7 @@ module.exports = function (chartType, Highcharts){
     },
 
     shouldComponentUpdate(nextProps) {
-      if (this.props.neverReflow || (this.props.isPureConfig  && this.props.config === nextProps.config)) {
+      if (nextProps.neverReflow || (nextProps.isPureConfig  && this.props.config === nextProps.config)) {
         return true;
       }
       this.renderChart(nextProps.config);


### PR DESCRIPTION
This makes the incoming config govern isPureConfig and neverReflow, which seems to be what was intended all along.

credit @sandorp