### PR TITLE
Update chartsFactory.jsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-highcharts",
-  "version": "8.4.1",
+  "version": "8.4.0",
   "description": "React wrapper for highcharts",
   "main": "dist/ReactHighcharts.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-highcharts",
-  "version": "8.4.0",
+  "version": "8.4.1",
   "description": "React wrapper for highcharts",
   "main": "dist/ReactHighcharts.js",
   "scripts": {

--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -1,5 +1,5 @@
 var React = require('react');
-var win = global || window;
+var win = typeof global === 'undefined' ? window : global;
 
 module.exports = function (chartType, Highcharts){
   var displayName = 'Highcharts' + chartType;

--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -1,4 +1,5 @@
 var React = require('react');
+var win = global || window;
 
 module.exports = function (chartType, Highcharts){
   var displayName = 'Highcharts' + chartType;
@@ -30,7 +31,7 @@ module.exports = function (chartType, Highcharts){
       }, this.props.callback);
 
       if (!this.props.neverReflow) {
-        global.requestAnimationFrame && requestAnimationFrame(()=>{
+        win.requestAnimationFrame && requestAnimationFrame(()=>{
           this.chart && this.chart.options && this.chart.reflow();
         });
       }


### PR DESCRIPTION
This creates a variable scoped to chartsFactory.jsx that attempts to use `global` (as was being used prior), but falls back to `window` when `global` is undefined.

This is to fix [#160](https://github.com/kirjs/react-highcharts/issues/160).