### PR TITLE
fix compatibility with react 15.2

### DIFF
--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -61,12 +61,7 @@ module.exports = function (chartType, Highcharts){
     },
 
     render: function (){
-      let props = this.props;
-      props = {
-        ...props,
-        ref: 'chart'
-      };
-      return <div {...props} />;
+      return <div ref="chart" />;
     }
   });
 


### PR DESCRIPTION
Newer version of react does not allow giving unsupported props
to dom elements. avoid giving the chart config to dom.

ref #164 

It seems to work good in the demo ... but not sure about the proposed changes