### PR TITLE
Remove internal (unknown) props from those that are passed to div

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Kirill Cherkashin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -61,6 +61,10 @@ module.exports = function (chartType, Highcharts){
     },
 
     render: function (){
+      /*
+        stripping out the internal props and creating new props
+        so that only valid (user-driven) props are passed to the div
+       */
       let {
           callback,
           config,

--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -62,10 +62,10 @@ module.exports = function (chartType, Highcharts){
 
     render: function (){
       let {
-          callback: callbackIgnored,
-          config: configIgnored,
-          isPureConfig: isPureConfigIgnored,
-          neverReflow: neverReflowIgnored,
+          callback,
+          config,
+          isPureConfig,
+          neverReflow,
           ...props
       } = this.props;
       props = {

--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -61,7 +61,13 @@ module.exports = function (chartType, Highcharts){
     },
 
     render: function (){
-      let props = this.props;
+      let {
+          callback: callbackIgnored,
+          config: configIgnored,
+          isPureConfig: isPureConfigIgnored,
+          neverReflow: neverReflowIgnored,
+          ...props
+      } = this.props;
       props = {
         ...props,
         ref: 'chart'


### PR DESCRIPTION
Use of destructuing to remove internal props from this.props (labeling them as ignored to be explicit), so that unknown props are not passed to the div