### PR TITLE
Allow for case where window and global don't exist

### DIFF
--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -33,7 +33,7 @@ module.exports = function (chartType, Highcharts){
       }, this.props.callback);
 
       if (!this.props.neverReflow) {
-        win.requestAnimationFrame && requestAnimationFrame(()=>{
+        win && win.requestAnimationFrame && requestAnimationFrame(()=>{
           this.chart && this.chart.options && this.chart.reflow();
         });
       }


### PR DESCRIPTION
This will prevent issues where neither the `window` or `global` exist. Which is OK in certain situations. All tests pass. Demos are fine.

The case I ran into, that requires this change, is issues where my test/test coverage reporting would break due to `window` being undefined.

```
ReferenceError: window is not defined
    at Object.eval (node_modules/react-highcharts/ReactHighstock.js:1:836)
    at Object.eval (node_modules/react-highcharts/ReactHighstock.js:1:2037)
    at r (node_modules/react-highcharts/ReactHighstock.js:1:442)
    at Object.t.exports (node_modules/react-highcharts/ReactHighstock.js:1:2114)
    at r (node_modules/react-highcharts/ReactHighstock.js:1:442)
    at Object.r.exports (node_modules/react-highcharts/ReactHighstock.js:1:562)
    at r (node_modules/react-highcharts/ReactHighstock.js:1:442)
    at eval (node_modules/react-highcharts/ReactHighstock.js:1:529)
    at eval (node_modules/react-highcharts/ReactHighstock.js:1:534)
```

Line #2 in `chartFactory.jsx` isn't completely safe and by adding the change in this PR, it is.
```js
var win = typeof global === 'undefined' ? window : global;
```