### PR TITLE
Add React 16 peer dependency and fix warning about defaultProps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "url": "https://github.com/kirjs/react-highcharts"
   },
   "peerDependencies": {
-    "react": "~0.14 || ^15.0.0",
-    "react-dom": "~0.14 || ^15.0.0"
+    "react": "~0.14 || ^15.0.0 || ^16.0.0",
+    "react-dom": "~0.14 || ^15.0.0 || ^16.0.0"
   },
   "bugs": "https://github.com/kirjs/react-highcharts/issues",
   "keywords": [

--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -15,12 +15,15 @@ module.exports = function (chartType, Highcharts){
       callback: PropTypes.func,
       domProps: PropTypes.object
     },
-
-    defaultProps: {
-      callback: () =>{},
-      domProps: {}
+    getDefaultProps: function() {
+      return {
+        callback: () =>{},
+        domProps: {}
+      };
     },
-
+    setChartRef: function(chartRef) {
+      this.chartRef = chartRef;
+    },
     renderChart: function (config){
       if (!config) {
         throw new Error('Config must be specified for the ' + displayName + ' component');
@@ -30,7 +33,7 @@ module.exports = function (chartType, Highcharts){
         ...config,
         chart: {
           ...chartConfig,
-          renderTo: this.refs.chart
+          renderTo: this.chartRef
         }
       }, this.props.callback);
 
@@ -65,7 +68,7 @@ module.exports = function (chartType, Highcharts){
     },
 
     render: function (){
-      return <div ref="chart" {...this.props.domProps} />;
+      return <div ref={this.setChartRef} {...this.props.domProps} />;
     }
   });
 


### PR DESCRIPTION
This PR makes react-highcharts work with React 16. I tested that it still works with React 15.6.2, don't know about 14. Probably it would be better to also remove React 0.14 from peerDependencies.

Fixes https://github.com/kirjs/react-highcharts/issues/324