### PR TITLE
Add highcharts version in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ react-highcharts
 
 [![Build Status](https://travis-ci.org/kirjs/react-highcharts.svg?branch=master)](https://travis-ci.org/kirjs/react-highcharts)
 
-Highcharts component for react.
+[Highcharts 5.x.x](https://www.highcharts.com/documentation/changelog) component for react.
 
 ## Demos
 [react-highcharts](http://kirjs.github.io/react-highcharts/)
@@ -97,7 +97,7 @@ require('highcharts-more')(ReactHighcharts.Highcharts)
 
 You can find the full list list [here](https://github.com/kirjs/publish-highcharts-modules/blob/master/modules.md)
 
-## Passing Highcharts instance manually 
+## Passing Highcharts instance manually
 ```javascript
 const ReactHighcharts = require('react-highcharts').withHighcharts(ReactHighstock)
 ```


### PR DESCRIPTION
Gave me a bit of head scratching when I tried to use word cloud which is only in`highcharts 6.x.x`. Thought it might be good if the document states the version of highcharts it is currently using