### PR TITLE
Fix defaultProps with React 16

### DIFF
--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -15,11 +15,9 @@ module.exports = function (chartType, Highcharts){
       callback: PropTypes.func,
       domProps: PropTypes.object
     },
-    getDefaultProps: function() {
-      return {
-        callback: () =>{},
-        domProps: {}
-      };
+    defaultProps: {
+      callback: () =>{},
+      domProps: {}
     },
     setChartRef: function(chartRef) {
       this.chartRef = chartRef;


### PR DESCRIPTION
Fix invalid property `getDefaultProps()` with React 16:

```
Warning: Setting defaultProps as an instance property on HighchartsChart is not supported and will be ignored. Instead, define defaultProps as a static property on HighchartsChart.
```