### PR TITLE
If a chart is already present it must be destroyed

### DIFF
--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -21,6 +21,9 @@ function chartsFactory(chartType, Highcharts) {
                 throw new Error('Config must be specified for the ' + this.displayName + ' component');
             }
             const chartConfig = config.chart;
+            if (this.chart) {
+                this.chart.destroy();
+            }
             this.chart = new this.Highcharts[this.chartType]({
                 ...config,
                 chart: {

--- a/test/unit/nonbundleSpec.js
+++ b/test/unit/nonbundleSpec.js
@@ -84,6 +84,28 @@ function nonBundleTest(lib, chartName, modulename){
         component.componentWillUnmount();
         assert(fakeHighchartsInstance.destroy.called);
       });
+
+      it('Destroys Highchart and rebuilds it when component gets updated', ()=>{
+        var fakeHighchartsInstance = {
+          destroy: sinon.stub()
+        };
+        var fakeConfig = {
+          chart: {
+            specialProp: {}
+          }
+        };
+        fakeHighcharts[chartName] = sinon.stub().returns(fakeHighchartsInstance);
+
+        var component = TestUtils.renderIntoDocument(
+          React.createElement(Component, {config: {}, callback: noop})
+        );
+
+        assert(!fakeHighchartsInstance.destroy.called);
+        component.shouldComponentUpdate({
+          config: fakeConfig
+        });
+        assert(fakeHighchartsInstance.destroy.called);
+      });
     });
 
     describe('WithHighcharts', ()=>{


### PR DESCRIPTION
To me this was causing this problem: https://github.com/kirjs/react-highcharts/issues/384

Moreover for sure many resources were  not released but on the contrary they were accumulating.
