### PR TITLE
fixed bug with trying to destroy undefined

### DIFF
--- a/src/chartsFactory.jsx
+++ b/src/chartsFactory.jsx
@@ -59,7 +59,9 @@ function chartsFactory(chartType, Highcharts) {
         }
 
         componentWillUnmount() {
-            this.chart.destroy();
+            if(this.chart){
+                this.chart.destroy();
+            }
         }
 
         render() {


### PR DESCRIPTION
I have been dealing with this bug for a while now where navigating away from the page that contained HighChart components would causes errors of failing to destroy undefined object during `componentWillUnmount`.

After doing some research and looking around at similar projects using this library, I noticed that other people had similar issues where the library would try to destroy an already undefined object. 

A common fix seemed to be checking to see if the chart existed before attempting to destroy it. This solved all the issues that I had with my application related to this error.