### PR TITLE
add demodist to .npmignore (reduces npm package size by ~80%)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 demo
+demodist
 .idea
 test


### PR DESCRIPTION
Hi, I have a question why is `demodist` included in the npm package? And a proposal to remove it.

I did not see any mention of `demodist` in the docs and therefore believe it should remain at the github repository as good practices and examples for people to use. Yet it should not be a part of the npm package. As you can see from an example below `demodist` takes up to 7.3M, while the whole package (without its dependencies) is 8.76M. This makes `demodist` approximately 80% portion of the package size which is not supposed to be used as a part of the npm package. I encourage to adding it no `.npmignore` to prevent it from bloating the package size.

Stats for v16.1.0
```sh
$ du -d 1 -h ~/my-project/node_modules/react-highcharts
7.3M	/Users/antonk52/my-project/node_modules/react-highcharts/demodist
1.4M	/Users/antonk52/my-project/node_modules/react-highcharts/dist
704K	/Users/antonk52/my-project/node_modules/react-highcharts/bundle
4.0K	/Users/antonk52/my-project/node_modules/react-highcharts/.github
 44K	/Users/antonk52/my-project/node_modules/react-highcharts/src
 10M	/Users/antonk52/my-project/node_modules/react-highcharts
```